### PR TITLE
Fix sphere-light PDF NaNs at the source instead of guarding the integrator

### DIFF
--- a/shaders.hlsl
+++ b/shaders.hlsl
@@ -124,31 +124,18 @@ void RayGeneration()
                     payload.pdfValue = 1.0f;
                 }
                 
-                float pdfRatio = payload.pdfScatter / payload.pdfValue;
-                
-                if (HasNaN(pdfRatio) || HasInf(pdfRatio))
-                {
-                    // Nan check. As of now the only sources of those are sphere light PDF values computation
-                    // formula taken from the book, which seems to cover some corner cases very poorly.
-                    // 1. One source is discriminant check which sometimes oscillates around 0 (actually it
-                    // sometimes has values like -0.00001) causing zero pdf values for rays validly sampled
-                    // from its PDF meaning they could also get zero pdf from cosine. If we get zero pdf for
-                    // both cosine and hittable, we end up with zero division in the ratio.
-                    // 2. Second source is the "1 / solidAngle" part which can cause NaNs if the solid angle
-                    // is very small due to the scatter point distance to the light.
-                    // I could fix both there but decided to make generic check right here in case something
-                    // similar pops up elsewhere.
-                    // 3. Third source is related to "sqrt(1 - lightSphereRadius * lightSphereRadius / distSquared)"
-                    // part which might cause a NaN if a scatter occur inside dielectric light source. This happens
-                    // in the final scene of part I where randomly created small spheres will sometimes overlap.
-                    // If you remove that part, you will see some occasional random black pixels popping up in
-                    // the image for cases where we sample over spheres. In case of third source (overlapping spheres)
-                    // the effect will be dramatic for higher samples per pixel (try it). What we do here is, if we
-                    // find such "bad" path being taken, we just terminate it.
-                    lastColor = float3(0, 0, 0);
-                    break;
-                }
-                
+                // pdfValue is the PDF of the distribution we actually sampled from, so for a
+                // validly sampled direction it must be strictly positive and finite. If a
+                // degenerate sphere-light PDF still makes it non-positive or non-finite (e.g. the
+                // discriminant oscillating around 0 producing a 0/0, or a vanishingly small solid
+                // angle), the path's Monte Carlo weight is taken as 0 and the path dies on the next
+                // loop iteration via the gatheredAttenuation check above. The comparison also handles
+                // NaN (NaN > 0 is false) and Inf (x / Inf == 0) for free. The previously problematic
+                // inside-the-sphere NaN is now fixed at its source in RandomToSphere and
+                // HittablePDFValue, which fall back to uniform sphere sampling when the origin is
+                // inside the light sphere (e.g. overlapping spheres in the final scene of part I).
+                float pdfRatio = (payload.pdfValue > 0.0f) ? payload.pdfScatter / payload.pdfValue : 0.0f;
+
                 gatheredAttenuation *= payload.color * pdfRatio;
                 --remainingReflections;
             }

--- a/shaders_helpers.hlsli
+++ b/shaders_helpers.hlsli
@@ -175,6 +175,14 @@ float3 RandomCosineDirection(inout uint seed)
 
 float3 RandomToSphere(inout uint seed, float radius, float distanceSquared)
 {
+    if (distanceSquared <= radius * radius)
+    {
+        // Origin is inside the sphere: the solid-angle (cone) sampling is undefined
+        // (sqrt(1 - radius^2 / distanceSquared) would go negative and produce a NaN).
+        // Fall back to uniform sphere sampling, consistent with HittablePDFValue.
+        return RandomUnitVector(seed);
+    }
+
     float r1 = RandomFloat(seed);
     float r2 = RandomFloat(seed);
     float z = 1 + r2 * (sqrt(1 - radius * radius / distanceSquared) - 1);
@@ -234,18 +242,29 @@ float HittablePDFValue(float3 hittablePdfOrigin, float3 scatterDirection)
             float  lightSphereRadius = g_objects[object].radius;
 
             float3 oc = lightSphereCenter - hittablePdfOrigin;
-            float  a = dot(scatterDirection, scatterDirection);
-            float  h = dot(scatterDirection, oc);
             float  distSquared = dot(oc, oc);
-            float  c = distSquared - lightSphereRadius * lightSphereRadius;
 
-            float  discriminant = h * h - a * c;
-            if (discriminant >= 0)
+            if (distSquared > lightSphereRadius * lightSphereRadius)
             {
-                float cosThetaMax = sqrt(1 - lightSphereRadius * lightSphereRadius / distSquared);
-                float solidAngle = 2 * PI() * (1 - cosThetaMax);
+                // Origin is outside the sphere: use the exact solid-angle (cone) PDF.
+                float  a = dot(scatterDirection, scatterDirection);
+                float  h = dot(scatterDirection, oc);
+                float  c = distSquared - lightSphereRadius * lightSphereRadius;
 
-                hittablePDFValue = 1 / solidAngle;
+                float  discriminant = h * h - a * c;
+                if (discriminant >= 0)
+                {
+                    float cosThetaMax = sqrt(1 - lightSphereRadius * lightSphereRadius / distSquared);
+                    float solidAngle = 2 * PI() * (1 - cosThetaMax);
+
+                    hittablePDFValue = 1 / solidAngle;
+                }
+            }
+            else
+            {
+                // Origin is inside the sphere: cone sampling is undefined, so we
+                // sample uniformly instead (matches RandomToSphere's fallback).
+                hittablePDFValue = 1 / (4 * PI());
             }
         }
     


### PR DESCRIPTION
## Summary

The raygen loop used to guard every bounce with a broad `HasNaN(pdfRatio) || HasInf(pdfRatio)` check and kill any offending path. As the comment there admitted, this was a **workaround** for degenerate values coming out of the analytic sphere-light PDF, not a fix for them. This PR addresses the root causes and replaces the catch-all with a single, locally-justified guard.

The old comment listed three NaN/Inf sources, which really fall into two kinds:

| # | Source | Nature | Fix |
|---|--------|--------|-----|
| 3 | Sampling a sphere light from **inside** that sphere (overlapping spheres / scatter inside a dielectric light) → `sqrt(1 - r²/distSquared)` goes imaginary | **Real bug** — the cone model is undefined inside the sphere | Fixed at the source |
| 1 | Discriminant in the *value* path oscillating around 0 (e.g. `-0.00001`) → `0/0` for diffuse | Float-edge inconsistency between generate/value | Guarded division |
| 2 | Vanishingly small solid angle → `1/solidAngle` blows up | Float-edge | Guarded division |

## Changes

**`shaders_helpers.hlsli` — fix the inside-the-sphere case at the source.** Both the *generate* path (`RandomToSphere`) and the *value* path (`HittablePDFValue`, sphere branch) now detect `distSquared <= radius²` and fall back to **uniform sphere sampling** (direction `RandomUnitVector`, PDF `1/4π`). Keeping the two paths consistent is what avoids a fresh `0/0`. This removes the NaN that the old comment noted was "dramatic for higher samples per pixel".

**`shaders.hlsl` — replace the per-bounce `HasNaN`/`HasInf` branch with a guarded division.**

```hlsl
float pdfRatio = (payload.pdfValue > 0.0f) ? payload.pdfScatter / payload.pdfValue : 0.0f;
```

`pdfValue` is the PDF of the distribution we actually sampled from, so for a valid sample it must be strictly positive and finite. If a degenerate value slips through, the path weight is taken as `0` and the path dies on the next iteration via the existing `length(gatheredAttenuation) < 0.0001` check — **behaviorally identical** to the old `break`-to-black. The `> 0` test also absorbs `NaN` (`NaN > 0` is false) and `Inf` (`x / Inf == 0`) for free.

## Notes
- `HasNaN`/`HasInf` in `shaders_helpers.hlsli` are now unused but left in place as general-purpose debugging helpers.
- This is a Windows/Visual Studio DXR project; the shaders are compiled there, so the change was validated by review rather than compiled in CI.

https://claude.ai/code/session_01TPtyZck89afg9SA1MZbbiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPtyZck89afg9SA1MZbbiG)_